### PR TITLE
优化Limit的调用

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -699,7 +699,9 @@ func (statement *Statement) Top(limit int) *Statement {
 
 // Limit generate LIMIT start, limit statement
 func (statement *Statement) Limit(limit int, start ...int) *Statement {
-	statement.LimitN = &limit
+	if limit > 0 {
+		statement.LimitN = &limit
+	}
 	if len(start) > 0 {
 		statement.Start = start[0]
 	}


### PR DESCRIPTION
要用到分布逻辑时，经常要根据limit要写条件，类似这样的

```go
if param.Limit > 0 {
		err = session.Limit(int(param.Limit), int(param.Start)).Find(&list)
	} else {
		err = session.Find(&list)
	}
```

在`Limit`方法中判断limit值，调用方可不用关心limit的大小