### PR TITLE
change goracle  to godror

### DIFF
--- a/dialects/dialect.go
+++ b/dialects/dialect.go
@@ -207,7 +207,7 @@ func regDrvsNDialects() bool {
 		"pgx":      {"postgres", func() Driver { return &pqDriverPgx{} }, func() Dialect { return &postgres{} }},
 		"sqlite3":  {"sqlite3", func() Driver { return &sqlite3Driver{} }, func() Dialect { return &sqlite3{} }},
 		"oci8":     {"oracle", func() Driver { return &oci8Driver{} }, func() Dialect { return &oracle{} }},
-		"goracle":  {"oracle", func() Driver { return &goracleDriver{} }, func() Dialect { return &oracle{} }},
+		"godror":   {"oracle", func() Driver { return &godrorDriver{} }, func() Dialect { return &oracle{} }},
 	}
 
 	for driverName, v := range providedDrvsNDialects {

--- a/dialects/oracle.go
+++ b/dialects/oracle.go
@@ -802,10 +802,10 @@ func (db *oracle) Filters() []Filter {
 	}
 }
 
-type goracleDriver struct {
+type godrorDriver struct {
 }
 
-func (cfg *goracleDriver) Parse(driverName, dataSourceName string) (*URI, error) {
+func (cfg *godrorDriver) Parse(driverName, dataSourceName string) (*URI, error) {
 	db := &URI{DBType: schemas.ORACLE}
 	dsnPattern := regexp.MustCompile(
 		`^(?:(?P<user>.*?)(?::(?P<passwd>.*))?@)?` + // [user[:password]@]

--- a/xormplus.go
+++ b/xormplus.go
@@ -9,7 +9,7 @@ const (
 	MYMYSQL_DRIVER    string = "mymysql"
 	POSTGRESQL_DRIVER string = "postgres"
 	OCI8_DRIVER       string = "oci8"
-	GORACLE_DRIVER    string = "goracle"
+	GORACLE_DRIVER    string = "godror"
 	SQLITE3_DRIVER    string = "sqlite3"
 )
 


### PR DESCRIPTION
for trademark issues, the original goracle   was been changed to godror，so this rep should also change.

> Goracle is deprecated because of naming (trademark) issues.
>Please use github.com/godror/godror instead!

ref: https://github.com/go-goracle/goracle