### PR TITLE
rows2mapObject虽然value是nil，但是有些场景需要这个key存在。如果json不希望有null数据存在，数据库中把value赋值为默认值就可以了。

### DIFF
--- a/helpers_plus.go
+++ b/helpers_plus.go
@@ -239,6 +239,7 @@ func rows2mapObject(rows *core.Rows, fields []string) (resultsMap map[string]int
 		rawValue := reflect.Indirect(reflect.ValueOf(scanResultContainers[ii]))
 		//if row is null then ignore
 		if rawValue.Interface() == nil {
+			result[key] = nil
 			continue
 		}
 


### PR DESCRIPTION
虽然value是nil，但是有些场景需要这个key存在。如果json不希望有null数据存在，数据库中把value赋值为默认值就可以了。