### PR TITLE
bug fix: release conn after query pk in cacheget

### DIFF
--- a/session_get.go
+++ b/session_get.go
@@ -321,16 +321,17 @@ func (session *Session) cacheGet(bean interface{}, sqlStr string, args ...interf
 		if err != nil {
 			return false, err
 		}
-		defer rows.Close()
-
 		if rows.Next() {
 			err = rows.ScanSlice(&res)
 			if err != nil {
+				rows.Close()
 				return false, err
 			}
 		} else {
+			rows.Close()
 			return false, ErrCacheFailed
 		}
+		rows.Close()
 
 		var pk schemas.PK = make([]interface{}, len(table.PrimaryKeys))
 		for i, col := range table.PKColumns() {


### PR DESCRIPTION
cacheget会先查询数据库中的pk，然后再查询cache，当并发数超过最大连接数时，查询pk的conn不会被释放，导致获取连接时锁死