### PR TITLE
解决原始sql加Limit函数分页出错问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # xorm
 xorm是一个简单而强大的Go语言ORM库. 通过它可以使数据库操作非常简便。
+新的在维护版本： [https://gitea.com/xorm/xorm](https://gitea.com/xorm/xorm)
 
 ## 说明
 

--- a/internal/statements/query.go
+++ b/internal/statements/query.go
@@ -29,7 +29,7 @@ func (statement *Statement) genSelectSql(dialect dialects.Dialect, rownumber str
 			if pLimitN != nil {
 				sql = fmt.Sprintf("%v LIMIT %v OFFSET %v", sql, *pLimitN, statement.Start)
 			} else {
-				sql = fmt.Sprintf("%v LIMIT 0 OFFSET %v", sql, *pLimitN)
+				sql = fmt.Sprintf("%v LIMIT 0 OFFSET %v", sql, statement.Start)
 			}
 		} else if pLimitN != nil {
 			sql = fmt.Sprintf("%v LIMIT %v", sql, *pLimitN)

--- a/internal/statements/query.go
+++ b/internal/statements/query.go
@@ -26,14 +26,13 @@ func (statement *Statement) genSelectSql(dialect dialects.Dialect, rownumber str
 
 	if dialect.URI().DBType != schemas.MSSQL && dialect.URI().DBType != schemas.ORACLE {
 		if statement.Start > 0 {
-			sql = fmt.Sprintf("%v LIMIT %v OFFSET %v", sql, statement.LimitN, statement.Start)
 			if pLimitN != nil {
 				sql = fmt.Sprintf("%v LIMIT %v OFFSET %v", sql, *pLimitN, statement.Start)
 			} else {
 				sql = fmt.Sprintf("%v LIMIT 0 OFFSET %v", sql, *pLimitN)
 			}
 		} else if pLimitN != nil {
-			sql = fmt.Sprintf("%v LIMIT %v", sql, statement.LimitN)
+			sql = fmt.Sprintf("%v LIMIT %v", sql, *pLimitN)
 		}
 	} else if dialect.URI().DBType == schemas.ORACLE {
 		if statement.Start != 0 || pLimitN != nil {


### PR DESCRIPTION
当我使用以下语句查询 Mysql 数据库表第一条数据时（无偏移，返回第一条）
r2, err2 := session.SQL("select dateValue FROM T_VL_ARTICLEINDD order by dateValue desc ").Limit(1).QueryValue()
拼接的sql语句limit参数错误，导致出错， limit参数为1，拼接参数为0xc000304578
[xorm] [info] 2022/06/01 20:00:23.472237 [SQL] select dateValue FROM T_VL_ARTICLEINDD order by dateValue desc LIMIT 0xc000304578 [] - 2.659ms
[] Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '0xc000304578' at line 1